### PR TITLE
AM-328: Increase icon size of focus areas

### DIFF
--- a/src/components/CreateMapathon/Summary.js
+++ b/src/components/CreateMapathon/Summary.js
@@ -115,28 +115,28 @@ class Summary extends React.Component {
                   {this.props.focusAreas[0] && (
                     <Icon
                       glyph="entrylg"
-                      size={1}
+                      size={2}
                       color={colors.darkestGrey}
                       alt="Entrance"
-                      style={{ margin: 'auto 0' }}
+                      style={{ margin: 'auto 5px auto 0px' }}
                     />
                   )}
                   {this.props.focusAreas[1] && (
                     <Icon
                       glyph="interior"
-                      size={1.0}
+                      size={2.5}
                       color={colors.darkestGrey}
                       alt="Interior"
-                      style={{ margin: 'auto 0' }}
+                      style={{ margin: 'auto 5px auto 0px' }}
                     />
                   )}
                   {this.props.focusAreas[2] && (
                     <Icon
                       glyph="restroom"
-                      size={1}
+                      size={2}
                       color={colors.darkestGrey}
                       alt="Restroom"
-                      style={{ margin: 'auto 0' }}
+                      style={{ margin: 'auto 5px auto 0px' }}
                     />
                   )}
                 </FocusAreas>


### PR DESCRIPTION
The icons were quite small before: 
![image](https://user-images.githubusercontent.com/30279572/213905790-3282be23-1ec3-417b-8403-eb24dfcb7dce.png)

Now:
![image](https://user-images.githubusercontent.com/30279572/213905752-017c953b-6218-4e3e-b92b-aa4316009d3d.png)
