### PR TITLE
feat: Add /sign-up page route to fix 404 for Google Ads

### DIFF
--- a/src/app/sign-up/layout.tsx
+++ b/src/app/sign-up/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign Up | AXS Map",
+  description: "Create your free AXS Map account to rate and review the accessibility of places around the world. Join our community making the world more accessible for everyone.",
+  openGraph: {
+    title: "Sign Up | AXS Map",
+    description: "Create your free AXS Map account to rate and review the accessibility of places around the world.",
+    url: "https://www.axsmap.com/sign-up",
+  },
+};
+
+export default function SignUpLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+import React from "react";
+import { useRouter } from "next/navigation";
+import CreateAccountForm from "@/components/create-account-form/create-account-form";
+import { AuthModalScreens } from "@/utils/types";
+
+export default function SignUpPage() {
+  const router = useRouter();
+
+  const handleClose = () => {
+    router.push("/");
+  };
+
+  const handleSetPage = (page: AuthModalScreens) => {
+    if (page === "Login") {
+      // Redirect to home and open login modal via URL param
+      router.push("/?login=true");
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8">
+        <CreateAccountForm
+          setPage={handleSetPage}
+          closeAuthModal={handleClose}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Created dedicated /sign-up page using existing CreateAccountForm
- Added SEO metadata with title, description, and OpenGraph tags
- Page is public, no authentication required
- Fixes Google Ads destination not working issue