### PR TITLE
feat: Implement "Remember Me" feature for login

### DIFF
--- a/src/Services/modules/auth/login.ts
+++ b/src/Services/modules/auth/login.ts
@@ -19,8 +19,5 @@ export type Response = {
 export type LoginPayload = {
   email: string;
   password: string;
-};
-
-export type remeberMe = LoginPayload & {
-  rememberMe: boolean;
+  rememberMe?: boolean;
 };

--- a/src/Services/modules/auth/loginWithFacebook.ts
+++ b/src/Services/modules/auth/loginWithFacebook.ts
@@ -29,4 +29,5 @@ export type LoginFacebookPayload = {
   code: string;
   web: string;
   redirectUri: string;
+  rememberMe?: boolean;
 };

--- a/src/Services/modules/auth/loginWithGoogle.ts
+++ b/src/Services/modules/auth/loginWithGoogle.ts
@@ -25,4 +25,5 @@ export type Response = {
 
 export type LoginGooglePayload = {
   code: string;
+  rememberMe?: boolean;
 };

--- a/src/app/auth/facebook/page.tsx
+++ b/src/app/auth/facebook/page.tsx
@@ -34,15 +34,27 @@ function FacebookCallbackContent(): React.ReactElement {
     const handleFacebookLogin = async () => {
       const code = searchParams.get("code");
       if (!code) return;
+      
+      // Get rememberMe preference from sessionStorage
+      const rememberMe = sessionStorage.getItem("rememberMe") === "true";
+      // Clear it after reading
+      sessionStorage.removeItem("rememberMe");
+      
       try {
         const data = await loginWithFacebook({
           code,
           web: "true",
           redirectUri: `${window.origin}/auth/facebook`,
+          rememberMe,
         }).unwrap();
         if (data.token) {
           dispatch(getTokenSuccess(data.token));
-          Cookies.set("token", data.token, { expires: 7 });
+          // Set cookie expiration based on rememberMe: 90 days if true, 7 days if false
+          const cookieExpiration = rememberMe ? 90 : 7;
+          Cookies.set("token", data.token, { expires: cookieExpiration });
+          if (data.refreshToken) {
+            Cookies.set("refreshToken", data.refreshToken, { expires: cookieExpiration });
+          }
           router.push("/");
         } else {
           console.error("No token returned from Facebook login.");

--- a/src/app/auth/google/page.tsx
+++ b/src/app/auth/google/page.tsx
@@ -33,10 +33,21 @@ function GoogleCallbackContent() {
     const handleGoogleLogin = async () => {
       const code = searchParams.get("code");
       if (!code) return;
+      
+      // Get rememberMe preference from sessionStorage
+      const rememberMe = sessionStorage.getItem("rememberMe") === "true";
+      // Clear it after reading
+      sessionStorage.removeItem("rememberMe");
+      
       try {
-        const data = await loginWithGoogle({ code }).unwrap();
+        const data = await loginWithGoogle({ code, rememberMe }).unwrap();
         dispatch(getTokenSuccess(data.token));
-        Cookies.set("token", data.token, { expires: 7 });
+        // Set cookie expiration based on rememberMe: 90 days if true, 7 days if false
+        const cookieExpiration = rememberMe ? 90 : 7;
+        Cookies.set("token", data.token, { expires: cookieExpiration });
+        if (data.refreshToken) {
+          Cookies.set("refreshToken", data.refreshToken, { expires: cookieExpiration });
+        }
         dispatch(getUserSuccess(data.user));
         router.push("/");
       } catch (error: any) {

--- a/src/components/LoginModal/LoginModal.tsx
+++ b/src/components/LoginModal/LoginModal.tsx
@@ -36,8 +36,10 @@ const Login: React.FC<AuthModalScreenProps> = ({ setPage, closeAuthModal }) => {
     try {
       const response = await login(formData).unwrap();
       dispatch(getTokenSuccess(response.token));
-      Cookies.set("token", response.token, { expires: 7 });
-      Cookies.set("refreshToken", response.refreshToken, { expires: 7 });
+      // Set cookie expiration based on rememberMe: 90 days if checked, 7 days if not
+      const cookieExpiration = formData.rememberMe ? 90 : 7;
+      Cookies.set("token", response.token, { expires: cookieExpiration });
+      Cookies.set("refreshToken", response.refreshToken, { expires: cookieExpiration });
       showToast({message:t("loginSuccessMessage"), type:'success'});
       closeAuthModal();
     } catch (error) {
@@ -47,6 +49,8 @@ const Login: React.FC<AuthModalScreenProps> = ({ setPage, closeAuthModal }) => {
     }
   };
   const handleGoogleLogin = () => {
+    // Store rememberMe preference before OAuth redirect
+    sessionStorage.setItem("rememberMe", formData.rememberMe.toString());
     const params = new URLSearchParams({
       client_id: process?.env?.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? '',
       redirect_uri: process?.env?.NEXT_PUBLIC_REDIRECT_URL ?? '',
@@ -59,6 +63,8 @@ const Login: React.FC<AuthModalScreenProps> = ({ setPage, closeAuthModal }) => {
   };
 
   const handleFacebookLogin = () => {
+    // Store rememberMe preference before OAuth redirect
+    sessionStorage.setItem("rememberMe", formData.rememberMe.toString());
     const params = new URLSearchParams({
       client_id: process.env.NEXT_PUBLIC_FACEBOOK_CLIENT_ID!,
       redirect_uri: `${window.location.origin}/auth/facebook`,


### PR DESCRIPTION
- Add rememberMe parameter to email/password login API call
- Add rememberMe parameter to Google OAuth login
- Add rememberMe parameter to Facebook OAuth login
- Store rememberMe preference in sessionStorage before OAuth redirect
- Set cookie expiration based on rememberMe (90 days if checked, 7 days if not)
- Update auth service types to include rememberMe field