### PR TITLE
fix: Pass frontendUrl in sign-up and forgot-password requests

### DIFF
--- a/src/Services/modules/auth/forgotPassword.ts
+++ b/src/Services/modules/auth/forgotPassword.ts
@@ -5,7 +5,11 @@ const forgotPasswordMutation = (build: EndpointBuilder<BaseQueryFn, string, stri
     query: data => ({
       url: `auth/forgotten-password`,
       method: 'POST',
-      body: data,
+      body: {
+        ...data,
+        // Include frontendUrl for environment-specific password reset links
+        frontendUrl: typeof window !== 'undefined' ? window.location.origin : undefined,
+      },
     }),
   });
 

--- a/src/Services/modules/auth/register.ts
+++ b/src/Services/modules/auth/register.ts
@@ -7,7 +7,11 @@ const registerMutation = (
     query: (data) => ({
       url: `auth/sign-up`,
       method: "POST",
-      body: data,
+      body: {
+        ...data,
+        // Include frontendUrl for environment-specific activation links
+        frontendUrl: typeof window !== 'undefined' ? window.location.origin : undefined,
+      },
     }),
   });
 


### PR DESCRIPTION
- Add frontendUrl (window.location.origin) to register mutation
- Add frontendUrl to forgotPassword mutation
- Enables environment-specific activation and password reset email links
- Fixes activation links pointing to production instead of test environment