### PR TITLE
feat: show both AXS Map and Google reviews on venue detail page

### DIFF
--- a/src/app/(main)/venue/[id]/page.tsx
+++ b/src/app/(main)/venue/[id]/page.tsx
@@ -212,15 +212,14 @@ const venueData: React.FC = () => {
             </div>
           )}
 
-          {/* Google Reviews Section - Show only if no AXS reviews */}
-          {(venueDetails?.axsReviews?.length === 0 || !venueDetails?.axsReviews) &&
-            (venueDetails?.googleData?.reviews ?? [])?.length > 0 && (
+          {/* Google Reviews Section - Always show when Google reviews exist */}
+          {(venueDetails?.googleData?.reviews ?? [])?.length > 0 && (
               <div className="mt-6 p-4">
                 <div className="mb-6">
                   <div className="flex items-center mb-2">
                     <FaStar className="w-5 h-5 text-yellow-500 mr-2" />
                     <h2 className="text-xl font-bold" id="google-reviews-heading">
-                      {t("venue.googleReviewsHeading", { count: venueDetails.googleData.reviews.length })}
+                      {t("venue.googleReviewsHeading", { count: Math.min(venueDetails.googleData.reviews.length, 5) })}
                     </h2>
                   </div>
                   <p className="text-sm text-gray-600">{t("venue.googleReviewsSubtext")}</p>
@@ -230,7 +229,9 @@ const venueData: React.FC = () => {
                   aria-labelledby="google-reviews-heading"
                   role="list"
                 >
-                  {venueDetails.googleData.reviews.map(
+                  {venueDetails.googleData.reviews
+                    .slice(0, 5)
+                    .map(
                     (review: any, index: number) => (
                       <li
                         key={`google-review-${index}`}
@@ -297,6 +298,10 @@ const venueData: React.FC = () => {
                     )
                   )}
                 </ul>
+                {/* Google Attribution - required by Google Places API TOS */}
+                <p className="mt-4 text-xs text-gray-400 text-right">
+                  {t("venue.googleAttribution")}
+                </p>
               </div>
             )}
 

--- a/src/translation/en.ts
+++ b/src/translation/en.ts
@@ -244,6 +244,7 @@ const en = {
     axsReviewsSubtext: "Community accessibility reviews from AXS Map users",
     googleReviewsHeading: "Google Reviews ({{count}})",
     googleReviewsSubtext: "General reviews from Google users",
+    googleAttribution: "Reviews provided by Google",
     providedNoComment: "User provided accessibility ratings without a written comment.",
     noRatings: "Venue has no ratings",
   },

--- a/src/translation/es.ts
+++ b/src/translation/es.ts
@@ -288,6 +288,7 @@ const es = {
     axsReviewsSubtext: "Reseñas de accesibilidad de la comunidad de usuarios de AXS Map",
     googleReviewsHeading: "Reseñas de Google ({{count}})",
     googleReviewsSubtext: "Reseñas generales de usuarios de Google",
+    googleAttribution: "Reseñas proporcionadas por Google",
     providedNoComment: "El usuario proporcionó calificaciones de accesibilidad sin comentario escrito.",
     noRatings: "El lugar no tiene calificaciones",
   },

--- a/src/translation/fr.ts
+++ b/src/translation/fr.ts
@@ -280,6 +280,7 @@ const fr = {
     axsReviewsSubtext: "Avis d'accessibilité de la communauté provenant des utilisateurs d'AXS Map",
     googleReviewsHeading: "Avis Google ({{count}})",
     googleReviewsSubtext: "Avis généraux des utilisateurs de Google",
+    googleAttribution: "Avis fournis par Google",
     providedNoComment: "L'utilisateur a fourni des évaluations d'accessibilité sans commentaire écrit.",
     noRatings: "Ce lieu n’a pas encore d’évaluations",
   },

--- a/src/translation/jp.ts
+++ b/src/translation/jp.ts
@@ -280,6 +280,7 @@ const jp = {
     axsReviewsSubtext: "AXS Map ユーザーからのコミュニティによるアクセシビリティレビュー",
     googleReviewsHeading: "Google レビュー ({{count}})",
     googleReviewsSubtext: "Google ユーザーによる一般的なレビュー",
+    googleAttribution: "Googleが提供するレビュー",
     providedNoComment: "ユーザーはテキストコメントなしでアクセシビリティ評価を提供しました。",
     noRatings: "この会場にはまだ評価がありません",
   },


### PR DESCRIPTION
- Remove exclusive condition that hid Google reviews when AXS reviews exist
- Both AXS Map community reviews and Google reviews now display together
- Limit Google reviews to max 5 for cleaner UI
- Add Google attribution text (required by Google Places API TOS)
- Add googleAttribution translation key in all 4 languages (en, es, fr, jp)