### PR TITLE
ci(prod): allow NEXT_PUBLIC_GOOGLE_API_KEY override

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -21,12 +21,21 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       #  Create .env file
-      - name: Create .env file 
+      - name: Create .env file
         shell: bash
+        env:
+          GOOGLE_API_KEY_OVERRIDE: ${{ secrets.NEXT_PUBLIC_GOOGLE_API_KEY }}
         run: |
           cat <<'EOF' > .env
           ${{ secrets.PROD_ENV }}
           EOF
+
+          # If a dedicated Google Maps key secret is set, override whatever
+          # PROD_ENV had for NEXT_PUBLIC_GOOGLE_API_KEY.
+          if [ -n "$GOOGLE_API_KEY_OVERRIDE" ]; then
+            sed -i '/^NEXT_PUBLIC_GOOGLE_API_KEY=/d' .env
+            echo "NEXT_PUBLIC_GOOGLE_API_KEY=$GOOGLE_API_KEY_OVERRIDE" >> .env
+          fi
 
       #  Build Docker image
       - name: Build Docker image


### PR DESCRIPTION
## Summary
- Adds an override path for the Google Maps key in the prod deploy workflow without touching the multi-line `PROD_ENV` secret.
- If the new repo secret `NEXT_PUBLIC_GOOGLE_API_KEY` is set, the workflow strips the existing line from `PROD_ENV`'s output and appends the new value. If the override secret is empty/missing, behavior is identical to today.

## Why
Updating `PROD_ENV` is risky — it's one giant multi-line secret and replacing it is all-or-nothing. Splitting the Google Maps key into its own secret lets us rotate the key independently.

## Test plan
- [ ] Confirm `NEXT_PUBLIC_GOOGLE_API_KEY` repo secret is set with the new key value
- [ ] Merge to `prod-next-app` and watch the workflow run on the self-hosted runner
- [ ] After deploy, hit the prod URL and verify the map loads (no `ExpiredKeyMapError` / `RefererNotAllowedMapError`)
- [ ] In Google Cloud Console, ensure the new key has the prod Amplify/site URL added to its HTTP referrer allowlist

## Rollback
Delete the `NEXT_PUBLIC_GOOGLE_API_KEY` repo secret — workflow will fall back to whatever `PROD_ENV` contains.