### PR TITLE
fix(leaderboard): show all 20 entries with standard ranking

### DIFF
--- a/src/app/(main)/leaderboard/page.tsx
+++ b/src/app/(main)/leaderboard/page.tsx
@@ -140,14 +140,16 @@ const LeaderboardPage = () => {
 
           {!isLoading && !isError && users.length > 0 ? (
             <div className="divide-y divide-gray-100">
-              {users.map((user) => (
+              {users.map((user, index) => {
+                const position = index + 1;
+                return (
                 <div
                   className="grid grid-cols-[72px_1fr_120px] items-center gap-3 px-4 py-4 md:grid-cols-[96px_1fr_180px]"
                   key={user.id}
                 >
                   <div className="flex items-center gap-2 font-semibold text-gray-900">
-                    {getRankIcon(user.ranking)}
-                    <span>#{user.ranking}</span>
+                    {getRankIcon(position)}
+                    <span>#{position}</span>
                   </div>
 
                   <div className="flex min-w-0 items-center gap-3">
@@ -183,7 +185,8 @@ const LeaderboardPage = () => {
                     </p>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           ) : null}
         </section>

--- a/src/app/(main)/leaderboard/page.tsx
+++ b/src/app/(main)/leaderboard/page.tsx
@@ -141,7 +141,13 @@ const LeaderboardPage = () => {
           {!isLoading && !isError && users.length > 0 ? (
             <div className="divide-y divide-gray-100">
               {users.map((user, index) => {
-                const position = index + 1;
+                // Standard ranking: ties share the rank of the first user
+                // in the tie group, the next distinct value skips ahead.
+                // e.g. with three tied at 203: …, #14, #14, #14, #17, #18, …
+                const firstTiedIndex = users.findIndex(
+                  (u) => u.reviewsAmount === user.reviewsAmount
+                );
+                const position = firstTiedIndex + 1;
                 return (
                 <div
                   className="grid grid-cols-[72px_1fr_120px] items-center gap-3 px-4 py-4 md:grid-cols-[96px_1fr_180px]"


### PR DESCRIPTION
## Summary
Follow-up to #182. The merged PR used the backend's dense rank for display, so three users tied at 203 reviews shared rank #14 and the visible rank labels stopped at #18 — making the leaderboard look like it was missing entries.

This PR switches the displayed rank to **standard "1224" ranking** computed client-side from `reviewsAmount`. Ties still share the same rank number (e.g. three users at #14), but the next distinct value skips ahead so the list runs all the way to #20.

## What it looks like now
```
#13 Deepshikha sharma  (215)
#14 Sherly Thankappan  (203)
#14 Fairy Lai          (203)
#14 Jacob Willow       (203)
#17 Amita Pharshy      (200)
#18 Phil Beder         (190)
#19 Messiah Mercado    (188)
#20 Nanette Cerretini  (177)
```

## Test plan
- [ ] Open `/leaderboard` after deploy
- [ ] Confirm the all-time tab shows 20 entries with the last position labelled `#20`
- [ ] Confirm three users tied at 203 reviews all share rank `#14`
- [ ] Toggle to "This month" — should still render correctly (typically fewer entries)